### PR TITLE
fix: Bugs de plan de adquisiciones

### DIFF
--- a/src/app/pages/planes/components/tabla-planes-adquisiciones/tabla-planes-adquisiciones.component.ts
+++ b/src/app/pages/planes/components/tabla-planes-adquisiciones/tabla-planes-adquisiciones.component.ts
@@ -62,7 +62,7 @@ export class TablaPlanesAdquisicionesComponent implements OnInit, OnDestroy {
       .select(getPlanes)
       .subscribe((planes: any) => {
         if (this.sharedService.IfStore(planes)) {
-          if (Object.keys(planes[0][0]).length) {
+          if (planes[0][0] && Object.keys(planes[0][0]).length) {
             this.datosPrueba = planes[0];
           } else {
             this.datosPrueba = [];

--- a/src/app/pages/registro-plan-adquisiciones/interfaces/interfaces.ts
+++ b/src/app/pages/registro-plan-adquisiciones/interfaces/interfaces.ts
@@ -290,7 +290,7 @@ export const CONFIGURACION_TABLA_FUENTES: any = {
             {
                 icon: 'fas fa-trash',
                 class: 'p-2',
-                label_i18n: 'editar_fuente_financiamiento'
+                label_i18n: 'eliminar_fuente_financiamiento'
             }
         ],
     },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -642,7 +642,7 @@
       "valor": "Valor",
       "fuentes_financiamiento": "Fuentes de Financiamiento",
       "porcentaje": "Porcentaje",
-      "editar_actividades_fuentes_asociadas": "Editar Actividades y Fuentes Asociadas",
+      "editar_actividades_fuentes_asociadas": "Editar Actividad y Fuentes Asociadas",
       "agregar_actividades_fuentes_asociadas": "Agregar Actividad y Fuentes Asociadas",
       "editar_fuente_financiamiento": "Editar Fuente de Financiamiento",
       "eliminar_fuente_financiamiento": "Eliminar Fuente de Financiamiento",


### PR DESCRIPTION
Ajustes al no encontrar planes existentes, se mostraba error y ahora permite añadir planes
Se cambia la interface de traducción para eliminación
Se cambia una traducción errónea de i18n

Resuelve: udistrital/financiera_documentacion#411